### PR TITLE
set_keepalive in NGinx config

### DIFF
--- a/localhost/nginx/default.conf
+++ b/localhost/nginx/default.conf
@@ -81,6 +81,11 @@ server {
                 return
             end
             ngx.var.token = res
+            local ok, err = red:set_keepalive(10000, 100)
+            if not ok then
+                ngx.say("failed to set keepalive: ", err)
+                return
+            end
         }
         proxy_set_header Authorization "Bearer ${token}";
         proxy_ssl_server_name on;

--- a/ssl/nginx/default-2.conf
+++ b/ssl/nginx/default-2.conf
@@ -67,6 +67,11 @@ server {
                 return
             end
             ngx.var.token = res
+            local ok, err = red:set_keepalive(10000, 100)
+            if not ok then
+                ngx.say("failed to set keepalive: ", err)
+                return
+            end
         }
         proxy_set_header Authorization "Bearer ${token}";
         proxy_ssl_server_name on;


### PR DESCRIPTION
I think the issue that we are experiencing is that as requests come in, each request opens a connection to redis, queries it, and then closes the connection. When traffic is coming in, too, the redis connection becomes a bottleneck. We can configure the set_keepalive option to actually keep the redis connection alive even if completely idle for a given amount of time (in this case 10 seconds). All idle but alive connections are now in a connection pool and as new requests come in, they will be sent to the already open connection in the pool.

Tested this in my environment and while it served all of my requests successfully, I wasn't able to generate a massive amount of traffic to confirm that overcame any bottlenecks. Still, it didnt BREAK anything.